### PR TITLE
Yaml metadata support

### DIFF
--- a/bin/generate-metadata-yaml
+++ b/bin/generate-metadata-yaml
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -euf
+
+USAGE="usage: generate-metadata-yaml <UFW-ROOT> <METADATA-YAML-TEMPLATE> <OUTPUT>
+
+The environment variable __GIT_VERSION_PREFIX__ has to be set. It should be
+either an empty string '' if the project uses the 'vMAJOR.MINOR.PATCH' format
+for release tags or e.g. 'EPOCH/' if the release tag format is
+'EPOCH/vMAJOR.MINOR.PATCH'."
+GIT_LIBRARY_RELATIVE='vcs-integration/git.sh'
+
+if [ "$#" != 3 ]
+then
+	echo "$USAGE"
+	exit 1
+fi
+
+ufw_root="$1"
+template="$2"
+output="$3"
+
+echo 'Generating metadata YAML file'
+
+# load git.sh library
+git_library="$(realpath "$ufw_root")/${GIT_LIBRARY_RELATIVE}"
+# shellcheck disable=SC1090
+. "$git_library"
+git_populate
+git_got_info && git_amend_versions
+
+output_dir="$(realpath "$(dirname "$output")")"
+mkdir -pv "$output_dir"
+
+# convert_boolean takes a boolean value in the '0' or '1' format and converts
+# it into YAML-compatible 'false' and 'true' values.
+convert_boolean() {
+	c_style_input="$1"
+	if [ "$c_style_input" = '0' ]
+	then
+		echo 'false'
+	elif [ "$c_style_input" = '1' ]
+	then
+		echo 'true'
+	else
+		echo "convert_boolean: Failed to convert '${c_style_input}' to YAML boolean"
+		exit 1
+	fi
+}
+
+__GIT_IS_CLEAN_RELEASE_BUILD__="$(convert_boolean "$__GIT_IS_CLEAN_RELEASE_BUILD__")"
+__GIT_DIRTY__="$(convert_boolean "$__GIT_DIRTY__")"
+
+sed \
+	-e "s/@@__GIT_IS_CLEAN_RELEASE_BUILD__@@/${__GIT_IS_CLEAN_RELEASE_BUILD__}/g" \
+	-e "s/@@__GIT_DIRTY__@@/${__GIT_DIRTY__}/g" \
+	-e "s/@@__GIT_HASH_FULL__@@/${__GIT_HASH_FULL__}/g" \
+	-e "s/@@__GIT_COMMITDATE_UNIX__@@/${__GIT_COMMITDATE_UNIX__}/g" \
+	-e "s/@@__GIT_MAJOR__@@/${__GIT_MAJOR__}/g" \
+	-e "s/@@__GIT_MINOR__@@/${__GIT_MINOR__}/g" \
+	-e "s/@@__GIT_PATCHLEVEL__@@/${__GIT_PATCHLEVEL__}/g" \
+	< "$template" > "$output"

--- a/vcs-integration/git.sh
+++ b/vcs-integration/git.sh
@@ -24,7 +24,7 @@
 #
 # The code uses the variable __GIT_VERSION_PREFIX__ as a string to match and
 # strip off of version tags. This allows users to use foobar/v1.0.0 to result
-# in v1.0.0 when __GIT_VERSION_PREFIX__='foobar'.
+# in v1.0.0 when __GIT_VERSION_PREFIX__='foobar/'.
 #
 #   git_amend_versions: Overrides the MAJOR_VERSION, MINOR_VERSION and
 #       PATCHLEVEL shell parameters using their git counterparts.

--- a/vcs-integration/git.sh
+++ b/vcs-integration/git.sh
@@ -7,6 +7,7 @@
 #
 #         __GIT_BRANCH__
 #         __GIT_COMMITDATE__
+#         __GIT_COMMITDATE_UNIX__
 #         __GIT_DESCRIPTION__
 #         __GIT_DIRTY__
 #         __GIT_HASH__
@@ -63,7 +64,7 @@ _git_increment_ () {
 }
 
 _git_commitdate_ () {
-    REPLY="$(date -d @"$(git show -s --format=%ct $1)" '+%Y-%m-%d')"
+    REPLY="$(date -d @"$(git show -s --format=%ct)" '+%Y-%m-%d')"
 }
 
 _git_hash_ () {

--- a/vcs-integration/git.sh
+++ b/vcs-integration/git.sh
@@ -63,7 +63,7 @@ _git_increment_ () {
 }
 
 _git_commitdate_ () {
-    REPLY="$(date -d @"$(git show -s --format=%ct --date=local $1)" '+%Y-%m-%d')"
+    REPLY="$(date -d @"$(git show -s --format=%ct $1)" '+%Y-%m-%d')"
 }
 
 _git_hash_ () {

--- a/vcs-integration/git.sh
+++ b/vcs-integration/git.sh
@@ -64,7 +64,7 @@ _git_increment_ () {
 }
 
 _git_commitdate_ () {
-    REPLY="$(date -d @"$(git show -s --format=%ct)" '+%Y-%m-%d')"
+    REPLY="$(date -ud @"$(git show -s --format=%ct)" '+%Y-%m-%d')"
 }
 
 _git_hash_ () {

--- a/vcs-integration/git.sh
+++ b/vcs-integration/git.sh
@@ -11,6 +11,7 @@
 #         __GIT_DESCRIPTION__
 #         __GIT_DIRTY__
 #         __GIT_HASH__
+#         __GIT_HASH_FULL__
 #         __GIT_INCREMENT__
 #         __GIT_MAJOR__
 #         __GIT_MINOR__
@@ -67,8 +68,8 @@ _git_commitdate_unix_ () {
     REPLY="$(git show -s --format=%ct)"
 }
 
-_git_hash_ () {
-    REPLY="$(git rev-parse HEAD | cut -c1-12)"
+_git_hash_full_ () {
+    REPLY="$(git rev-parse HEAD)"
 }
 
 _git_branch_ () {
@@ -140,6 +141,7 @@ git_populate () {
     __GIT_DESCRIPTION__=''
     __GIT_DIRTY__=0
     __GIT_HASH__=''
+    __GIT_HASH_FULL__=''
     __GIT_INCREMENT__=0
     __GIT_MAJOR__=0
     __GIT_MINOR__=0
@@ -168,8 +170,9 @@ git_populate () {
             __GIT_DIRTY__=0
         fi
 
-        _git_hash_
-        __GIT_HASH__="$REPLY"
+        _git_hash_full_
+        __GIT_HASH_FULL__="$REPLY"
+        __GIT_HASH__="$(echo "$REPLY" | cut -c1-12)"
 
         _git_version_
         __GIT_VERSION__="$REPLY"
@@ -246,6 +249,7 @@ git_populate () {
         __GIT_DESCRIPTION__=""
         __GIT_DIRTY__=""
         __GIT_HASH__=""
+        __GIT_HASH_FULL__=""
         __GIT_INCREMENT__=""
         __GIT_MAJOR__=""
         __GIT_MINOR__=""

--- a/vcs-integration/git.sh
+++ b/vcs-integration/git.sh
@@ -63,8 +63,8 @@ _git_increment_ () {
     REPLY="$(git rev-list --count "$1"..HEAD)"
 }
 
-_git_commitdate_ () {
-    REPLY="$(date -ud @"$(git show -s --format=%ct)" '+%Y-%m-%d')"
+_git_commitdate_unix_ () {
+    REPLY="$(git show -s --format=%ct)"
 }
 
 _git_hash_ () {
@@ -136,6 +136,7 @@ git_str_is_int () {
 git_populate () {
     __GIT_BRANCH__=''
     __GIT_COMMITDATE__=''
+    __GIT_COMMITDATE_UNIX__=''
     __GIT_DESCRIPTION__=''
     __GIT_DIRTY__=0
     __GIT_HASH__=''
@@ -154,8 +155,9 @@ git_populate () {
         _git_branch_
         __GIT_BRANCH__="$REPLY"
 
-        _git_commitdate_
-        __GIT_COMMITDATE__="$REPLY"
+        _git_commitdate_unix_
+        __GIT_COMMITDATE_UNIX__="$REPLY"
+        __GIT_COMMITDATE__="$(date -ud "@${__GIT_COMMITDATE_UNIX__}" "+%Y-%m-%d")"
 
         _git_description_
         __GIT_DESCRIPTION__="$REPLY"


### PR DESCRIPTION
This branch adds the `generate-metadata-yaml` script which is similar to the already existing `generate-version-h` script but adapted to be used with YAML files instead of C header files.

Furthermore two new environment variables are provided by the `git.sh` library:

- `__GIT_HASH_FULL__`
- `__GIT_COMMITDATE_UNIX__`

This extends the use cases in which UFW can generate metadata files to be included in builds.

Additionally an issue is fixed which led to not reproducible builds.