### PR TITLE
Remove unintended output in metadata generation

### DIFF
--- a/bin/generate-metadata-yaml
+++ b/bin/generate-metadata-yaml
@@ -20,8 +20,6 @@ ufw_root="$1"
 template="$2"
 output="$3"
 
-echo 'Generating metadata YAML file'
-
 # load git.sh library
 git_library="$(realpath "$ufw_root")/${GIT_LIBRARY_RELATIVE}"
 # shellcheck disable=SC1090


### PR DESCRIPTION
This should correct the mistake of unintended stdout output. Please only adopt if this really improves consistency (I would guess that it does).